### PR TITLE
forces Travis to use "trusty" image as rabbitmq integration is broken…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: cpp
 cache: apt
 env:


### PR DESCRIPTION
… since Travis updated to "xenial"

refer to https://travis-ci.community/t/is-rabbitmq-service-down/4362/2